### PR TITLE
Ads support for Markdown when composing an e-mail

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -3,6 +3,7 @@
 namespace Kilowhat\Mailing;
 
 use Flarum\Extend;
+use Illuminate\Contracts\View\Factory;
 
 return [
     (new Extend\Frontend('forum'))
@@ -14,4 +15,7 @@ return [
     (new Extend\Routes('api'))
         ->post('/admin-mail', 'kilowhat.mailing.create-mail', Controllers\SendAdminEmailController::class),
     new \Kilowhat\Mailing\Extend\Permissions,
+    new Extend\Compat(function (Factory $views) {
+		$views->addNamespace('kilowhat-mailing', __DIR__ . '/resources/views');
+	})
 ];

--- a/resources/views/default.blade.php
+++ b/resources/views/default.blade.php
@@ -1,0 +1,11 @@
+<html>
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    {!! $body !!}
+</body>
+
+</html>

--- a/src/Controllers/SendAdminEmailController.php
+++ b/src/Controllers/SendAdminEmailController.php
@@ -16,6 +16,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Zend\Diactoros\Response\JsonResponse;
+use s9e\TextFormatter\Bundles\Fatdown;
 
 class SendAdminEmailController implements RequestHandlerInterface
 {
@@ -112,7 +113,9 @@ class SendAdminEmailController implements RequestHandlerInterface
 
     protected function sendMail(string $email, string $subject, string $text)
     {
-        $this->mailer->send(['raw' => $text], [], function (Message $message) use ($email, $subject) {
+        $formated_text = Fatdown::render(Fatdown::parse($text));
+
+        $this->mailer->send('kilowhat-mailing::default', ['body' => $formated_text], function (Message $message) use ($email, $subject) {
             $message->to($email);
             $message->subject('[' . $this->settings->get('forum_title') . '] ' . ($subject !== '' ? $subject : $this->translator->trans('kilowhat-mailing.email.default_subject')));
         });


### PR DESCRIPTION
This will now be sending HTML e-mails by default. 
Maybe there should be an option in the `EmailUserModal` to let the user choose to activate this feature or not. I could add this of course but I did't have the time right now. 